### PR TITLE
chore: add Prettier config and run Prettier

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,7 @@
 {
   "presets": [
-    "@babel/preset-env", 
-    "@babel/preset-react",  
+    "@babel/preset-env",
+    "@babel/preset-react",
     "@babel/preset-typescript"
   ]
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,33 +1,28 @@
 module.exports = {
-    parser: '@typescript-eslint/parser',
-    extends: [
-      'eslint:recommended',
-      'plugin:react/recommended',
-      'plugin:@typescript-eslint/recommended',
-      'prettier'
-    ],
-    parserOptions: {
-      ecmaVersion: "latest",
-      sourceType: "module",
-      ecmaFeatures: {
-        jsx: true
-      }
+  parser: "@typescript-eslint/parser",
+  extends: [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier",
+  ],
+  parserOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module",
+    ecmaFeatures: {
+      jsx: true,
     },
-    settings: {
-      react: {
-        version: 'detect'
-      }
+  },
+  settings: {
+    react: {
+      version: "detect",
     },
-    rules: {
-      "@typescript-eslint/no-unused-vars": ["warn"],
-      "@typescript-eslint/no-explicit-any": "warn",
-      "react/prop-types": "off",
-      "no-unused-vars": "off"
-    },
-    plugins: [
-      "react",
-      "@typescript-eslint",
-      "prettier"
-    ]
-  };
-  
+  },
+  rules: {
+    "@typescript-eslint/no-unused-vars": ["warn"],
+    "@typescript-eslint/no-explicit-any": "warn",
+    "react/prop-types": "off",
+    "no-unused-vars": "off",
+  },
+  plugins: ["react", "@typescript-eslint", "prettier"],
+};

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+# Ignore artifacts:
+build
+coverage
+dist
+
+node_modules
+

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": false,
+  "printWidth": 80,
+  "trailingComma": "es5"
+}

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "eslint-config-react-app": "^7.0.1",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "prettier": "3.5.3",
         "ts-jest": "^29.2.6",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.2",
@@ -11584,6 +11585,22 @@
       "peer": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "dev": "vite",
     "start": "vite",
-    "prettier": "prettier --write",
+    "prettier": "prettier . --write",
     "build": "vite build",
     "preview": "vite preview",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "scripts": {
     "dev": "vite",
     "start": "vite",
+    "prettier": "prettier --write",
     "build": "vite build",
     "preview": "vite preview",
     "test": "jest",
@@ -67,6 +68,7 @@
     "eslint-config-react-app": "^7.0.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "prettier": "3.5.3",
     "ts-jest": "^29.2.6",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.2",

--- a/src/App.css
+++ b/src/App.css
@@ -38,7 +38,7 @@ input[type="number"] {
 
 /* Add an active class to highlight the current page */
 .topnav a.active {
-  background-color: #F467A9;
+  background-color: #f467a9;
   color: white;
 }
 
@@ -53,7 +53,7 @@ input[type="number"] {
     display: block;
     font-size: 15px;
   }
-   .logo-and-hamburger {
+  .logo-and-hamburger {
     display: flex;
     justify-content: space-between;
     align-items: center;

--- a/src/components/soldierUnitAsRender.tsx
+++ b/src/components/soldierUnitAsRender.tsx
@@ -836,8 +836,8 @@ class soldierUnitAsRender extends React.Component<Props, State> {
             color: this.state.isToggleOnPoisoned
               ? "##CE93D8" // Set to #ce93d8 when isToggleOnPoisoned is true
               : this.state.isBecamePoisoned
-              ? "#008000" // Set to green when becamePoisoned is true
-              : "#A9A9A9", // Default color
+                ? "#008000" // Set to green when becamePoisoned is true
+                : "#A9A9A9", // Default color
           }}
         >
           {this.state.isToggleOnPoisoned ? <b>pois</b> : "pois"}

--- a/src/components/soldierUnitAsRenderBeta.tsx
+++ b/src/components/soldierUnitAsRenderBeta.tsx
@@ -840,8 +840,8 @@ class soldierUnitAsRenderBeta extends React.Component<Props, State> {
             color: this.state.isToggleOnPoisoned
               ? "##CE93D8" // Set to #ce93d8 when isToggleOnPoisoned is true
               : this.state.isBecamePoisoned
-              ? "#008000" // Set to green when becamePoisoned is true
-              : "#A9A9A9", // Default color
+                ? "#008000" // Set to green when becamePoisoned is true
+                : "#A9A9A9", // Default color
           }}
         >
           {this.state.isToggleOnPoisoned ? <b>pois</b> : "pois"}

--- a/src/images.d.ts
+++ b/src/images.d.ts
@@ -1,4 +1,4 @@
 declare module "*.png" {
-    const value: string;
-    export default value;
-  }
+  const value: string;
+  export default value;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,15 +1,25 @@
 body {
   margin: auto;
-  font-family: "Josefin Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
+  font-family:
+    "Josefin Sans",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    "Roboto",
+    "Oxygen",
+    "Ubuntu",
+    "Cantarell",
+    "Fira Sans",
+    "Droid Sans",
+    "Helvetica Neue",
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background: linear-gradient(to bottom , #ff5baa, #f7cf85);
+  background: linear-gradient(to bottom, #ff5baa, #f7cf85);
   min-height: 100vh;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
-    monospace;
+  font-family:
+    source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,8 +10,9 @@ import { isLocal } from "./firebase";
 console.log("Rendering App...");
 // window.process = window.process || {}; // Fix for Firebase env vars
 
-
-const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
+const root = ReactDOM.createRoot(
+  document.getElementById("root") as HTMLElement
+);
 root.render(
   <React.StrictMode>
     <BrowserRouter>

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,8 +1,8 @@
-import { Metric } from 'web-vitals';
+import { Metric } from "web-vitals";
 
 const reportWebVitals = (onPerfEntry?: (metric: Metric) => void) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
-    import('web-vitals').then(({ onCLS,  onFCP, onLCP, onTTFB }) => {
+    import("web-vitals").then(({ onCLS, onFCP, onLCP, onTTFB }) => {
       onCLS(onPerfEntry);
       onFCP(onPerfEntry);
       onLCP(onPerfEntry);

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,18 +1,18 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-    readonly VITE_FIREBASE_API_KEY: string;
-    readonly VITE_FIREBASE_AUTH_DOMAIN: string;
-    readonly VITE_FIREBASE_PROJECT_ID: string;
-    readonly VITE_FIREBASE_STORAGE_BUCKET: string;
-    readonly VITE_FIREBASE_MESSAGING_SENDER_ID: string;
-    readonly VITE_FIREBASE_APP_ID: string;
-    readonly VITE_FIREBASE_MEASUREMENT_ID: string;
-    readonly VITE_GOOGLE_SITE_VERIFICATION: string;
-    readonly VITE_CUSTOM_DOMAIN: string;
-    readonly VITE_EMAIL: string;
-  }
-  
-  interface ImportMeta {
-    readonly env: ImportMetaEnv;
-  }
+  readonly VITE_FIREBASE_API_KEY: string;
+  readonly VITE_FIREBASE_AUTH_DOMAIN: string;
+  readonly VITE_FIREBASE_PROJECT_ID: string;
+  readonly VITE_FIREBASE_STORAGE_BUCKET: string;
+  readonly VITE_FIREBASE_MESSAGING_SENDER_ID: string;
+  readonly VITE_FIREBASE_APP_ID: string;
+  readonly VITE_FIREBASE_MEASUREMENT_ID: string;
+  readonly VITE_GOOGLE_SITE_VERIFICATION: string;
+  readonly VITE_CUSTOM_DOMAIN: string;
+  readonly VITE_EMAIL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,9 +15,7 @@
     "isolatedModules": true,
     "noEmit": false,
     "jsx": "react-jsx",
-    "types": ["react", "react-dom", "jest", "node"],
-    },
-  "include": [
-    "src"
-  ]
+    "types": ["react", "react-dom", "jest", "node"]
+  },
+  "include": ["src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,21 +1,21 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
-import path from 'path';
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import path from "path";
 
 export default defineConfig({
   plugins: [react()],
-  root: '.', // Changed from './src' to project root
-  publicDir: 'public',
+  root: ".", // Changed from './src' to project root
+  publicDir: "public",
   build: {
-    outDir: 'dist',
+    outDir: "dist",
     sourcemap: true,
   },
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      "@": path.resolve(__dirname, "./src"),
     },
   },
   server: {
-    port: 3000
-  }
+    port: 3000,
+  },
 });


### PR DESCRIPTION
I've installed Prettier and added the following prettierrc:
```
{
  "tabWidth": 2,
  "semi": true,
  "singleQuote": false,
  "printWidth": 80,
  "trailingComma": "es5"
}
```
Turns out this doesn't affect many of the tsx files that much, so it should be similar to the previous Prettier that was run.

Let me know if you like these, or if you want to have different config. e.g. 4 tab width instead of 2