### PR TITLE
feat: add fallback route to redirect unmatched paths to home

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,23 +1,18 @@
 export default {
     preset: "ts-jest",
     testEnvironment: "jsdom",
-    transform: {
-        "^.+\\.tsx?$": [
-            "ts-jest",
-            {
-                tsconfig: "tsconfig.jest.json",
-                useESM: true,
-            },
-        ],
-    },
-    extensionsToTreatAsEsm: [".ts", ".tsx"],
+    setupFilesAfterEnv: [
+        "<rootDir>/jest.setup.ts",
+        "@testing-library/jest-dom",
+    ],
     moduleNameMapper: {
-        "\\.(jpg|jpeg|png|gif|svg)$": "<rootDir>/__mocks__/fileMock.js",
-        "^src/firebase$": "<rootDir>/__mocks__/firebaseMock.js",
-        "^src/firebase.ts$": "<rootDir>/__mocks__/firebaseMock.js",
-        "^(\\.{1,2}/.*)\\.js$": "$1",
+        "\\.(css|less|scss|sass)$": "identity-obj-proxy",
     },
-    setupFilesAfterEnv: ["<rootDir>/src/setupTests.ts"],
-    testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.[jt]sx?$",
-    moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+    testMatch: [
+        "**/__tests__/**/*.[jt]s?(x)",
+        "**/?(*.)+(spec|test).[jt]s?(x)",
+    ],
+    transform: {
+        "^.+\\.(ts|tsx)$": "ts-jest",
+    },
 };

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,4 @@
+import { TextEncoder, TextDecoder } from "util";
+
+global.TextEncoder = TextEncoder as typeof global.TextEncoder;
+global.TextDecoder = TextDecoder as typeof global.TextDecoder;

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
                 "babel-jest": "^29.7.0",
                 "eslint-config-prettier": "^10.0.2",
                 "eslint-config-react-app": "^7.0.1",
+                "identity-obj-proxy": "^3.0.0",
                 "jest": "^29.7.0",
                 "jest-environment-jsdom": "^29.7.0",
                 "prettier": "^3.5.3",
@@ -8801,6 +8802,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/harmony-reflect": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+            "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
+            "dev": true,
+            "license": "(Apache-2.0 OR MPL-1.1)"
+        },
         "node_modules/has-bigints": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -8992,6 +9000,19 @@
             "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
             "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
             "license": "ISC"
+        },
+        "node_modules/identity-obj-proxy": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+            "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "harmony-reflect": "^1.4.6"
+            },
+            "engines": {
+                "node": ">=4"
+            }
         },
         "node_modules/ignore": {
             "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
         "ts-jest": "^29.2.6",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.2",
-        "vite": "^6.2.0"
+        "vite": "^6.2.0",
+        "identity-obj-proxy": "^3.0.0"
     }
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import App from "./App";
+import "@testing-library/jest-dom";
+
+// Mock the child components
+jest.mock("./components/navbar", () => () => (
+    <div data-testid="navbar">Navbar</div>
+));
+jest.mock("./components/helpPage", () => () => (
+    <div data-testid="help-page">Help Page</div>
+));
+jest.mock("./components/secretGame", () => () => (
+    <div data-testid="secret-game">Secret Game</div>
+));
+jest.mock("./components/battleGroundDetails", () => () => (
+    <div data-testid="battle-ground">Battle Ground</div>
+));
+
+describe("App Routing", () => {
+    const renderWithRouter = (initialRoute: string) => {
+        return render(
+            <MemoryRouter initialEntries={[initialRoute]}>
+                <App />
+            </MemoryRouter>
+        );
+    };
+
+    test("renders home page at /", () => {
+        renderWithRouter("/");
+        expect(screen.getByTestId("battle-ground")).toBeInTheDocument();
+    });
+
+    test("renders help page at /help", () => {
+        renderWithRouter("/help");
+        expect(screen.getByTestId("help-page")).toBeInTheDocument();
+    });
+
+    test("renders secret game at /secretgame", () => {
+        renderWithRouter("/secretgame");
+        expect(screen.getByTestId("secret-game")).toBeInTheDocument();
+    });
+
+    test("redirects unknown routes to home page", () => {
+        renderWithRouter("/unknown-route");
+        expect(screen.getByTestId("battle-ground")).toBeInTheDocument();
+    });
+
+    test("navbar is present on all routes", () => {
+        renderWithRouter("/");
+        expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route, Navigate } from "react-router-dom";
 import "./App.css";
 import NavBar from "./components/navbar";
 import HelpPage from "./components/helpPage";
@@ -23,6 +23,7 @@ const App = () => {
                     <Route path="/help" element={<HelpPage />} />
                     <Route path="/" element={<BattleGroundDetails />} />
                     <Route path="/secretgame" element={<SecretGame />} />
+                    <Route path="*" element={<Navigate to="/" replace />} />
                 </Routes>
             </div>
         </ThemeProvider>


### PR DESCRIPTION
Right now if you navigate to https://polytopia-damage-calculator.firebaseapp.com/beta because that url is in your browser history or bookmarks, the router doesn't know what component to load. This change makes it so that any paths that are not declared as a valid route get redirected to the main page or `/`.
cc @amigobrewbrew @br-Chan 

![image](https://github.com/user-attachments/assets/58222f99-48e0-4c84-a41e-2879a15d6967)
