### PR TITLE
Stiff & surprise retaliation checks and damage calculation revamp

### DIFF
--- a/src/components/battleGroundDetails.tsx
+++ b/src/components/battleGroundDetails.tsx
@@ -30,6 +30,7 @@ import {
     calculateAttackResult,
     calculateAttackSplash,
     calculateDefenceForce,
+    calculateDefenseResult,
     calculateTotalDamage,
 } from "../utils/damageFormulae";
 
@@ -581,21 +582,16 @@ const BattleGroundDetails = () => {
             defender.healthAfter = defender.healthBefore - totalAttackResult;
 
             if (defender.healthAfter > 0) {
-                const defenceResult = Math.round(
-                    parseFloat(
-                        (
-                            (defenseForce / totalDamage) *
-                            defender.config.defence *
-                            4.5
-                        ).toFixed(10)
-                    )
+                const defenceResult = calculateDefenseResult(
+                    defenseForce,
+                    totalDamage,
+                    defender.config.defence
                 );
                 console.log("This is defenceResult:" + defenceResult);
+
                 if (
-                    ["Exida", "Phychi", "Kiton", "Segment"].includes(
-                        attacker.typeUnit
-                    ) ||
-                    attacker.explodeDamage
+                    attacker.config.skills.includes("poison") ||
+                    attacker.typeUnit === "Segment"
                 ) {
                     defender.becamePoisonedBonus = true;
                     poisoningAttacker = attacker.id;
@@ -603,13 +599,15 @@ const BattleGroundDetails = () => {
 
                 if (
                     !attacker.config.skills.includes("surprise") &&
-                    !defender.config.skills.includes("stiff")
+                    !defender.config.skills.includes("stiff") &&
+                    !attacker.safeBonus
                 ) {
                     attacker.healthAfter =
                         attacker.healthBefore - defenceResult;
-                }
-
-                if (attacker.typeUnit === "Segment" || attacker.explodeDamage) {
+                } else if (
+                    attacker.explodeDamage ||
+                    attacker.typeUnit === "Segment"
+                ) {
                     attacker.healthAfter = 0;
                 }
             } else {

--- a/src/components/battleGroundDetails.tsx
+++ b/src/components/battleGroundDetails.tsx
@@ -539,7 +539,7 @@ const BattleGroundDetails = () => {
 
             const defenseForce = calculateDefenceForce(
                 defender.config.defence,
-                defender.healthBefore,
+                defender.healthAfter,
                 defender.healthMax,
                 defenderDefenseBonus
             );

--- a/src/components/battleGroundDetails.tsx
+++ b/src/components/battleGroundDetails.tsx
@@ -601,8 +601,15 @@ const BattleGroundDetails = () => {
                     defender.becamePoisonedBonus = true;
                     poisoningAttacker = attacker.id;
                 }
-                attacker.healthAfter =
-                    attacker.healthBefore - defenceResult * safeBonusMultiplier;
+
+                if (
+                    !attacker.config.skills.includes("surprise") &&
+                    !defender.config.skills.includes("stiff")
+                ) {
+                    attacker.healthAfter =
+                        attacker.healthBefore - defenceResult;
+                }
+
                 if (attacker.typeUnit === "Segment" || attacker.explodeDamage) {
                     attacker.healthAfter = 0;
                 }

--- a/src/components/battleGroundDetails.tsx
+++ b/src/components/battleGroundDetails.tsx
@@ -529,13 +529,14 @@ const BattleGroundDetails = () => {
                 attacker.healthMax
             );
 
-            const defenderDefenseBonus = defender.poisonedBonus
-                ? 0.7
-                : defender.wallBonus
-                  ? 4
-                  : defender.defenceBonus
-                    ? 1.5
-                    : 1;
+            const defenderDefenseBonus =
+                defender.poisonedBonus || defender.becamePoisonedBonus
+                    ? 0.7
+                    : defender.wallBonus
+                      ? 4
+                      : defender.defenceBonus
+                        ? 1.5
+                        : 1;
 
             const defenseForce = calculateDefenceForce(
                 defender.config.defence,

--- a/src/components/battleGroundDetails.tsx
+++ b/src/components/battleGroundDetails.tsx
@@ -25,6 +25,7 @@ import { SoldierUnit } from "../types/SoldierUnit";
 import { UnitConfig, VersionConfig } from "../types/VersionConfig";
 import { useSearchParams } from "react-router-dom";
 import { LATEST_VERSION } from "../config/version.global";
+import { calculateAttackForce } from "../utils/damageFormulae";
 
 const analyticsLogEvent = isLocal ? analytics.logEvent : logEvent;
 
@@ -530,12 +531,15 @@ const BattleGroundDetails = () => {
 
             const boostedBonusMultiplier = attacker.boostedBonus ? 1 : 0;
 
-            const attackForce = parseFloat(
-                (
-                    ((attacker.config.attack + 0.5 * boostedBonusMultiplier) *
-                        attacker.healthBefore) /
-                    attacker.healthMax
-                ).toFixed(10)
+            const attackerAttack =
+                attacker.config.attack + (attacker.boostedBonus ? 0.5 : 0);
+            const attackerHealth = attacker.healthBefore;
+            const attackerMaxHealth = attacker.healthMax;
+
+            const attackForce = calculateAttackForce(
+                attackerAttack,
+                attackerHealth,
+                attackerMaxHealth
             );
 
             const defenceForce = parseFloat(

--- a/src/components/soldierUnitAsRender.tsx
+++ b/src/components/soldierUnitAsRender.tsx
@@ -752,7 +752,10 @@ const SoldierUnitAsRender = ({
                 }}
                 style={{
                     display:
-                        soldierUnit.team === "Attackers" ? "visible" : "none",
+                        soldierUnit.team === "Attackers" &&
+                        !soldierUnit.config.skills.includes("surprise")
+                            ? "visible"
+                            : "none",
                     ...getSecondaryButtonStyles(),
                 }}
                 sx={{

--- a/src/utils/damageFormulae.ts
+++ b/src/utils/damageFormulae.ts
@@ -1,0 +1,49 @@
+export const calculateAttackForce = (
+    attack: number,
+    health: number,
+    maxHealth: number
+): number => {
+    return attack * (health / maxHealth);
+};
+
+export const calculateDefenceForce = (
+    defense: number,
+    health: number,
+    maxHealth: number,
+    defenseBonus: number
+): number => {
+    return defense * (health / maxHealth) * defenseBonus;
+};
+
+export const calculateTotalDamage = (
+    attackForce: number,
+    defenseForce: number
+): number => {
+    return attackForce + defenseForce;
+};
+
+export const calculateAttackResult = (
+    attackForce: number,
+    totalDamage: number,
+    attack: number
+): number => {
+    const attackRatio = Math.round(attackForce / totalDamage);
+    return attackRatio * attack * 4.5;
+};
+
+export const calculateAttackSplash = (
+    attackForce: number,
+    totalDamage: number,
+    attack: number
+): number => {
+    return calculateAttackResult(attackForce, totalDamage, attack) / 2;
+};
+
+export const calculateDefenseResult = (
+    defenseForce: number,
+    totalDamage: number,
+    defense: number
+): number => {
+    const defenseRatio = Math.round(defenseForce / totalDamage);
+    return defenseRatio * defense * 4.5;
+};

--- a/src/utils/damageFormulae.ts
+++ b/src/utils/damageFormulae.ts
@@ -27,8 +27,8 @@ export const calculateAttackResult = (
     totalDamage: number,
     attack: number
 ): number => {
-    const attackRatio = Math.round(attackForce / totalDamage);
-    return attackRatio * attack * 4.5;
+    const attackRatio = attackForce / totalDamage;
+    return Math.round(attackRatio * attack * 4.5);
 };
 
 export const calculateAttackSplash = (
@@ -36,7 +36,7 @@ export const calculateAttackSplash = (
     totalDamage: number,
     attack: number
 ): number => {
-    return calculateAttackResult(attackForce, totalDamage, attack) / 2;
+    return Math.round(calculateAttackResult(attackForce, totalDamage, attack) / 2);
 };
 
 export const calculateDefenseResult = (

--- a/src/utils/damageFormulae.ts
+++ b/src/utils/damageFormulae.ts
@@ -44,6 +44,6 @@ export const calculateDefenseResult = (
     totalDamage: number,
     defense: number
 ): number => {
-    const defenseRatio = Math.round(defenseForce / totalDamage);
-    return defenseRatio * defense * 4.5;
+    const defenseRatio = defenseForce / totalDamage;
+    return Math.round(defenseRatio * defense * 4.5);
 };


### PR DESCRIPTION
This PR closes #36 
- Created util functions for damage calculation.
- Cleaned up main damage calculation function. Replaced many boolean variables which are now integrated into the util functions or handled inline.
- Checked unit skills (e.g. stiff, surprise, poison) during damage calculation.
- Removed the 'safe' button from units with surprise, and they will always take 0 retaliation dmg.

Hope this didn't mess up damage calculation. I've tested it a bit already with various units, but let me know if you spot a bug. 

Also, do you want to keep the console logs during damage calculation (e.g. 'this is attackForce')? I would prefer removing them, and only adding them temporarily when we want to test the code. But up to you, it doesn't hurt to keep them there.