### PR TITLE
feat: version change toast

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import SecretGame from "./components/secretGame";
 import BattleGroundDetails from "./components/battleGroundDetails";
 import { createTheme, ThemeProvider } from "@mui/material/styles";
 import envConfig from "./envConfig";
+import { SnackBarProvider } from "./providers/snackbarContextProvider";
 
 // Create theme once outside of component to avoid recreation on every render
 const theme = createTheme({
@@ -18,22 +19,24 @@ const theme = createTheme({
 const App = () => {
     return (
         <ThemeProvider theme={theme}>
-            <meta
-                name="google-site-verification"
-                content={envConfig.siteVerification}
-            />
-            <React.Fragment key="adsense-script">
-                <script async src={envConfig.adsenseClient}></script>
-            </React.Fragment>{" "}
-            <NavBar />
-            <div className="containers">
-                <Routes>
-                    <Route path="/help" element={<HelpPage />} />
-                    <Route path="/" element={<BattleGroundDetails />} />
-                    <Route path="/secretgame" element={<SecretGame />} />
-                    <Route path="*" element={<Navigate to="/" replace />} />
-                </Routes>
-            </div>
+            <SnackBarProvider>
+                <meta
+                    name="google-site-verification"
+                    content={envConfig.siteVerification}
+                />
+                <React.Fragment key="adsense-script">
+                    <script async src={envConfig.adsenseClient}></script>
+                </React.Fragment>{" "}
+                <NavBar />
+                <div className="containers">
+                    <Routes>
+                        <Route path="/help" element={<HelpPage />} />
+                        <Route path="/" element={<BattleGroundDetails />} />
+                        <Route path="/secretgame" element={<SecretGame />} />
+                        <Route path="*" element={<Navigate to="/" replace />} />
+                    </Routes>
+                </div>
+            </SnackBarProvider>
         </ThemeProvider>
     );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,43 +1,33 @@
-import React, { useState } from "react";
+import React from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 import "./App.css";
 import NavBar from "./components/navbar";
 import HelpPage from "./components/helpPage";
 import SecretGame from "./components/secretGame";
 import BattleGroundDetails from "./components/battleGroundDetails";
-import { createTheme, ThemeProvider } from "@mui/material/styles";
 import envConfig from "./envConfig";
-import { SnackBarProvider } from "./providers/snackbarContextProvider";
-
-// Create theme once outside of component to avoid recreation on every render
-const theme = createTheme({
-    typography: {
-        fontFamily: "Josefin Sans, Arial, sans-serif",
-    },
-});
+import { AppProvider } from "./providers/appProvider";
 
 const App = () => {
     return (
-        <ThemeProvider theme={theme}>
-            <SnackBarProvider>
-                <meta
-                    name="google-site-verification"
-                    content={envConfig.siteVerification}
-                />
-                <React.Fragment key="adsense-script">
-                    <script async src={envConfig.adsenseClient}></script>
-                </React.Fragment>{" "}
-                <NavBar />
-                <div className="containers">
-                    <Routes>
-                        <Route path="/help" element={<HelpPage />} />
-                        <Route path="/" element={<BattleGroundDetails />} />
-                        <Route path="/secretgame" element={<SecretGame />} />
-                        <Route path="*" element={<Navigate to="/" replace />} />
-                    </Routes>
-                </div>
-            </SnackBarProvider>
-        </ThemeProvider>
+        <AppProvider>
+            <meta
+                name="google-site-verification"
+                content={envConfig.siteVerification}
+            />
+            <React.Fragment key="adsense-script">
+                <script async src={envConfig.adsenseClient}></script>
+            </React.Fragment>
+            <NavBar />
+            <div className="containers">
+                <Routes>
+                    <Route path="/help" element={<HelpPage />} />
+                    <Route path="/" element={<BattleGroundDetails />} />
+                    <Route path="/secretgame" element={<SecretGame />} />
+                    <Route path="*" element={<Navigate to="/" replace />} />
+                </Routes>
+            </div>
+        </AppProvider>
     );
 };
 

--- a/src/components/battleGroundDetails.tsx
+++ b/src/components/battleGroundDetails.tsx
@@ -33,6 +33,7 @@ import {
     calculateDefenseResult,
     calculateTotalDamage,
 } from "../utils/damageFormulae";
+import GameVersionSelect from "./gameVersionSelect";
 
 const analyticsLogEvent = isLocal ? analytics.logEvent : logEvent;
 
@@ -761,41 +762,13 @@ const BattleGroundDetails = () => {
             </Box>
 
             {versionConfig && (
-                <CardWithShadow sx={{ p: "3px 2%", width: "100%" }}>
-                    <Box
-                        component="span"
-                        sx={{
-                            display: "flex",
-                            flexDirection: "column",
-                            typography: "body2",
-                        }}
-                    >
-                        <FormControl sx={{ my: 1, minWidth: 120 }} size="small">
-                            <InputLabel id="version-select-label">
-                                Game version
-                            </InputLabel>
-                            <Select
-                                labelId="version-select-label"
-                                id="version-select"
-                                value={versionConfig.version}
-                                label="Game version"
-                                onChange={handleGameVersionChange}
-                            >
-                                {" "}
-                                {Object.entries(versionConfigs)
-                                    .sort(([a], [b]) => b.localeCompare(a))
-                                    .map(([version, config]) => (
-                                        <MenuItem key={version} value={version}>
-                                            {version} - {config.title}
-                                        </MenuItem>
-                                    ))}
-                            </Select>
-                        </FormControl>
-                        <span>
-                            Build version: {versionConfig?.buildVersion}
-                        </span>
-                    </Box>
-                </CardWithShadow>
+                <GameVersionSelect
+                    versionConfig={versionConfig}
+                    versionConfigs={versionConfigs}
+                    handleGameVersionChange={(event) =>
+                        handleGameVersionChange(event)
+                    }
+                />
             )}
         </Box>
     );

--- a/src/components/battleGroundDetails.tsx
+++ b/src/components/battleGroundDetails.tsx
@@ -14,13 +14,7 @@ import {
     SINGLE_COL_MAX_WIDTH_PX,
     SINGLE_COLUMN_WIDTH_PERCENTAGE,
 } from "../customStyles";
-import {
-    FormControl,
-    InputLabel,
-    MenuItem,
-    Select,
-    SelectChangeEvent,
-} from "@mui/material";
+import { SelectChangeEvent } from "@mui/material";
 import { SoldierUnit } from "../types/SoldierUnit";
 import { UnitConfig, VersionConfig } from "../types/VersionConfig";
 import { useSearchParams } from "react-router-dom";
@@ -34,11 +28,13 @@ import {
     calculateTotalDamage,
 } from "../utils/damageFormulae";
 import GameVersionSelect from "./gameVersionSelect";
+import { useSnackBar } from "../providers/snackbarContextProvider";
 
 const analyticsLogEvent = isLocal ? analytics.logEvent : logEvent;
 
 const BattleGroundDetails = () => {
     const [searchParams, setSearchParams] = useSearchParams();
+    const { showSnackBar } = useSnackBar();
 
     const [versionConfigs, setVersionConfigs] = useState<
         Record<string, VersionConfig>
@@ -91,6 +87,8 @@ const BattleGroundDetails = () => {
         analyticsLogEvent(analytics, "pc_version_changed_" + version);
         setSearchParams({ version: version });
         setVersionConfig(versionConfigs[version]);
+
+        showSnackBar(`Version changed to ${version}`, "success");
     };
 
     const handleChangeCheckbox = (): void => {

--- a/src/components/gameVersionSelect.tsx
+++ b/src/components/gameVersionSelect.tsx
@@ -15,11 +15,11 @@ type GameVersionSelectProps = {
     handleGameVersionChange: (event: SelectChangeEvent) => void;
 };
 
-const gameVersionSelect = ({
+const gameVersionSelect: React.FC<GameVersionSelectProps> = ({
     versionConfig,
     versionConfigs,
     handleGameVersionChange,
-}: GameVersionSelectProps) => {
+}) => {
     return (
         <CardWithShadow sx={{ p: "3px 2%", width: "100%" }}>
             <Box

--- a/src/components/gameVersionSelect.tsx
+++ b/src/components/gameVersionSelect.tsx
@@ -1,0 +1,59 @@
+import {
+    Box,
+    FormControl,
+    InputLabel,
+    Select,
+    MenuItem,
+    SelectChangeEvent,
+} from "@mui/material";
+import CardWithShadow from "./cardWithShadow";
+import { VersionConfig } from "../types/VersionConfig";
+
+type GameVersionSelectProps = {
+    versionConfig: VersionConfig;
+    versionConfigs: Record<string, VersionConfig>;
+    handleGameVersionChange: (event: SelectChangeEvent) => void;
+};
+
+const gameVersionSelect = ({
+    versionConfig,
+    versionConfigs,
+    handleGameVersionChange,
+}: GameVersionSelectProps) => {
+    return (
+        <CardWithShadow sx={{ p: "3px 2%", width: "100%" }}>
+            <Box
+                component="span"
+                sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    typography: "body2",
+                }}
+            >
+                <FormControl sx={{ my: 1, minWidth: 120 }} size="small">
+                    <InputLabel id="version-select-label">
+                        Game version
+                    </InputLabel>
+                    <Select
+                        labelId="version-select-label"
+                        id="version-select"
+                        value={versionConfig.version}
+                        label="Game version"
+                        onChange={handleGameVersionChange}
+                    >
+                        {Object.entries(versionConfigs)
+                            .sort(([a], [b]) => b.localeCompare(a))
+                            .map(([version, config]) => (
+                                <MenuItem key={version} value={version}>
+                                    {version} - {config.title}
+                                </MenuItem>
+                            ))}
+                    </Select>
+                </FormControl>
+                <span>Build version: {versionConfig?.buildVersion}</span>
+            </Box>
+        </CardWithShadow>
+    );
+};
+
+export default gameVersionSelect;

--- a/src/providers/appProvider.tsx
+++ b/src/providers/appProvider.tsx
@@ -1,0 +1,11 @@
+import { SnackBarProvider } from "./snackbarContextProvider";
+import { ThemeProvider } from "./themeProvider";
+
+// Wrapper for all providers. Add providers here.
+export const AppProvider = ({ children }: { children: React.ReactNode }) => {
+    return (
+        <ThemeProvider>
+            <SnackBarProvider>{children}</SnackBarProvider>
+        </ThemeProvider>
+    );
+};

--- a/src/providers/snackbarContextProvider.tsx
+++ b/src/providers/snackbarContextProvider.tsx
@@ -1,0 +1,55 @@
+// Boilerplate from: https://gist.github.com/akinncar/a9a87537768287fc2c1ed7c7d77d9433
+
+import { Alert, AlertColor, Snackbar } from "@mui/material";
+import { createContext, useContext, useState } from "react";
+
+type SnackBarContextActions = {
+    showSnackBar: (text: string, severity: AlertColor) => void;
+};
+
+const SnackBarContext = createContext({} as SnackBarContextActions);
+
+type SnackBarContextProviderProps = {
+    children: React.ReactNode;
+};
+
+const SnackBarProvider: React.FC<SnackBarContextProviderProps> = ({
+    children,
+}) => {
+    const [open, setOpen] = useState(false);
+    const [message, setMessage] = useState("");
+    const [severity, setSeverity] = useState<AlertColor>("info");
+
+    const showSnackBar = (text: string, color: AlertColor = "info") => {
+        setMessage(text);
+        setSeverity(color);
+        setOpen(true);
+    };
+
+    const handleClose = () => {
+        setOpen(false);
+        setSeverity("info");
+    };
+
+    return (
+        <SnackBarContext value={{ showSnackBar }}>
+            <Snackbar
+                open={open}
+                autoHideDuration={5000}
+                anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+                onClose={handleClose}
+            >
+                <Alert onClose={handleClose} severity={severity}>
+                    {message}
+                </Alert>
+            </Snackbar>
+            {children}
+        </SnackBarContext>
+    );
+};
+
+const useSnackBar = (): SnackBarContextActions => {
+    return useContext(SnackBarContext);
+};
+
+export { SnackBarProvider, useSnackBar };

--- a/src/providers/themeProvider.tsx
+++ b/src/providers/themeProvider.tsx
@@ -1,0 +1,16 @@
+import { createTheme, ThemeProvider as MuiThemeProvider } from "@mui/material";
+
+type ThemeProviderProps = {
+    children: React.ReactNode;
+};
+
+// Create theme once outside of component to avoid recreation on every render
+const theme = createTheme({
+    typography: {
+        fontFamily: "Josefin Sans, Arial, sans-serif",
+    },
+});
+
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
+    return <MuiThemeProvider theme={theme}>{children}</MuiThemeProvider>;
+};


### PR DESCRIPTION
I thought it would be useful to have a toast/snackbar notification appear when changing game versions, because if there aren't any units on the board there is nothing visual to show that the version change happened. Let me know if you like this!

Demo:
https://github.com/user-attachments/assets/a65231c5-f453-4dd4-8886-8739caeb7a0d

I used [boilerplate code](https://gist.github.com/akinncar/a9a87537768287fc2c1ed7c7d77d9433) to implement a snackbar context provider. So from now on we can use `useSnackbar("message", "success")` instead of repeating the code suggested in the [MUI docs](https://mui.com/material-ui/react-snackbar).

Since there are now 2 providers (theme provider + snackbar provider), I've created a wrapper called AppProvider to contain current and future providers. App.tsx then simply imports and uses AppProvider. Let me know if you're okay with this.

I also migrated the game version select bar into its own component.