### PR TITLE
fix: squash splash calculation bug

### DIFF
--- a/src/components/battleGroundDetails.tsx
+++ b/src/components/battleGroundDetails.tsx
@@ -550,12 +550,10 @@ const BattleGroundDetails = () => {
 
             let attackResult = 0;
             if (attacker.explodeDamage || attacker.typeUnit === "Segment") {
-                attackResult = Math.round(
-                    calculateAttackSplash(
-                        attackForce,
-                        totalDamage,
-                        attackerAttack
-                    )
+                attackResult = calculateAttackSplash(
+                    attackForce,
+                    totalDamage,
+                    attackerAttack
                 );
             } else if (
                 attacker.splashDamage &&
@@ -575,11 +573,6 @@ const BattleGroundDetails = () => {
                 );
             }
 
-            console.log("This is attackForce:" + attackForce);
-            console.log("This is defenseForce:" + defenseForce);
-            console.log("This is totalDamage:" + totalDamage);
-            console.log("This is attackResult:" + attackResult);
-
             totalAttackResult += attackResult;
             defender.healthAfter = defender.healthBefore - totalAttackResult;
 
@@ -589,7 +582,6 @@ const BattleGroundDetails = () => {
                     totalDamage,
                     defender.config.defence
                 );
-                console.log("This is defenceResult:" + defenceResult);
 
                 if (
                     attacker.config.skills.includes("poison") ||

--- a/src/utils/damageFormulae.ts
+++ b/src/utils/damageFormulae.ts
@@ -3,6 +3,7 @@ export const calculateAttackForce = (
     health: number,
     maxHealth: number
 ): number => {
+    console.log(attack + "*" + health + "/" + maxHealth);
     return attack * (health / maxHealth);
 };
 
@@ -12,6 +13,7 @@ export const calculateDefenceForce = (
     maxHealth: number,
     defenseBonus: number
 ): number => {
+    console.log(defense + "*" + health + "/" + maxHealth + "*" + defenseBonus);
     return defense * (health / maxHealth) * defenseBonus;
 };
 
@@ -28,6 +30,7 @@ export const calculateAttackResult = (
     attack: number
 ): number => {
     const attackRatio = attackForce / totalDamage;
+    console.log(attackRatio + "*" + attack + "*" + "4.5");
     return Math.round(attackRatio * attack * 4.5);
 };
 
@@ -36,7 +39,7 @@ export const calculateAttackSplash = (
     totalDamage: number,
     attack: number
 ): number => {
-    return Math.round(calculateAttackResult(attackForce, totalDamage, attack) / 2);
+    return calculateAttackResult(attackForce, totalDamage, attack) / 2;
 };
 
 export const calculateDefenseResult = (


### PR DESCRIPTION
I've simply removed the rounding of splash attack result - I'm now testing to make sure this is all that's required. 

[Reddit post](https://www.reddit.com/r/Polytopia/comments/1m0k11v/is_this_damage_calculator_up_to_date_i_did_this/):
<img width="1005" height="857" alt="image" src="https://github.com/user-attachments/assets/3e155c45-20b9-40a5-b379-dc828b08ab98" />
