### PR TITLE
improve the ui: (drag and drop order) and (switch attackers and defenders) and (consistent location for new units)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -108,3 +108,41 @@ body {
   font-family: Arial;
   text-align: center;
 } */
+
+/* Drag-and-drop animations for columns and cards */
+.dnd-column {
+    transition:
+        transform 200ms ease,
+        opacity 200ms ease;
+}
+
+.dnd-column.swap-out-left {
+    transform: translateX(-12px);
+    opacity: 0.85;
+}
+
+.dnd-column.swap-out-right {
+    transform: translateX(12px);
+    opacity: 0.85;
+}
+
+.dnd-card {
+    transition:
+        transform 180ms ease,
+        box-shadow 180ms ease;
+}
+
+.dnd-card.dragging {
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
+}
+
+/* Visual indicator when a card can be swapped/dropped here */
+.dnd-drop-target {
+    outline: 2px solid #2196f3;
+    outline-offset: -2px;
+}
+
+/* Hide the original list card while dragging (custom preview follows cursor) */
+.dnd-card.being-dragged {
+    opacity: 0;
+}

--- a/src/components/battleGroundDetails.tsx
+++ b/src/components/battleGroundDetails.tsx
@@ -6,8 +6,7 @@ import {
     SelectChangeEvent,
 } from "@mui/material";
 import Box from "@mui/material/Box";
-import Checkbox from "@mui/material/Checkbox";
-import FormControlLabel from "@mui/material/FormControlLabel";
+// removed Checkbox and FormControlLabel (order toggle no longer used)
 import { logEvent } from "firebase/analytics";
 import { useCallback, useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
@@ -51,7 +50,27 @@ const BattleGroundDetails = () => {
         useState<SoldierUnit[]>([]);
     // const [defIdxArray, setDefIdxArray] = useState<number[]>([]);
     // const [attIdxArray, setAttIdxArray] = useState<number[]>([]);
-    const [checkedPosition, setCheckedPosition] = useState(false);
+    const [dragContext, setDragContext] = useState<{
+        team: "Attackers" | "Defenders";
+        index: number;
+    } | null>(null);
+    const [isSwappingColumns, setIsSwappingColumns] = useState<
+        null | "toAttackers" | "toDefenders"
+    >(null);
+    const [hoverTarget, setHoverTarget] = useState<{
+        team: "Attackers" | "Defenders";
+        index: number;
+    } | null>(null);
+    const [dragPreview, setDragPreview] = useState<{
+        team: "Attackers" | "Defenders";
+        index: number;
+        clientX: number;
+        clientY: number;
+        clickOffsetX: number;
+        clickOffsetY: number;
+        width: number;
+        height: number;
+    } | null>(null);
 
     useEffect(() => {
         loadAllConfigs().then((configs) => {
@@ -92,9 +111,130 @@ const BattleGroundDetails = () => {
         setVersionConfig(versionConfigs[version]);
     };
 
-    const handleChangeCheckbox = (): void => {
-        setCheckedPosition((prev) => !prev);
-        analyticsLogEvent(analytics, "pc_checkbox_toggled");
+    const handleDragStart = (
+        e: React.DragEvent,
+        team: "Attackers" | "Defenders",
+        index: number
+    ) => {
+        setDragContext({ team, index });
+        e.dataTransfer.effectAllowed = "move";
+        const target = e.currentTarget as HTMLElement;
+        target.classList.add("dnd-card", "dragging");
+        // Create invisible drag image and render our own preview
+        const rect = target.getBoundingClientRect();
+        const clickOffsetX = e.clientX - rect.left;
+        const clickOffsetY = e.clientY - rect.top;
+        const ghost = document.createElement("div");
+        ghost.style.width = `${rect.width}px`;
+        ghost.style.height = `${rect.height}px`;
+        ghost.style.opacity = "0";
+        document.body.appendChild(ghost);
+        e.dataTransfer.setDragImage(ghost, clickOffsetX, clickOffsetY);
+        setTimeout(() => document.body.removeChild(ghost), 0);
+        setDragPreview({
+            team,
+            index,
+            clientX: e.clientX,
+            clientY: e.clientY,
+            clickOffsetX,
+            clickOffsetY,
+            width: rect.width,
+            height: rect.height,
+        });
+    };
+
+    const handleDrag = (e: React.DragEvent) => {
+        if (!dragContext || !dragPreview) return;
+        setDragPreview((prev) =>
+            prev
+                ? {
+                      ...prev,
+                      clientX: e.clientX,
+                      clientY: e.clientY,
+                  }
+                : prev
+        );
+    };
+
+    const handleDragOver = (e: React.DragEvent) => {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "move";
+        if (dragContext) {
+            setDragPreview((prev) =>
+                prev
+                    ? { ...prev, clientX: e.clientX, clientY: e.clientY }
+                    : prev
+            );
+        }
+    };
+
+    const handleDragEnd = (e: React.DragEvent) => {
+        const target = e.currentTarget as HTMLElement;
+        target.classList.remove("dragging");
+        setIsSwappingColumns(null);
+        setHoverTarget(null);
+        setDragPreview(null);
+        setDragContext(null);
+    };
+
+    const moveWithin = (
+        list: SoldierUnit[],
+        fromIdx: number,
+        toIdx: number
+    ): SoldierUnit[] => {
+        const newList = [...list];
+        const [moved] = newList.splice(fromIdx, 1);
+        newList.splice(toIdx, 0, moved);
+        return newList.map((u, i) => ({ ...u, id: i }));
+    };
+
+    const handleDrop = (
+        e: React.DragEvent,
+        targetTeam: "Attackers" | "Defenders",
+        targetIndex: number
+    ) => {
+        e.preventDefault();
+        if (!dragContext) return;
+
+        const { team: sourceTeam, index: sourceIndex } = dragContext;
+        setDragContext(null);
+        setHoverTarget(null);
+        setDragPreview(null);
+
+        if (sourceTeam === targetTeam) {
+            if (targetTeam === "Attackers") {
+                setSoldierUnitsAttackersAsRender((prev) =>
+                    moveWithin(prev, sourceIndex, targetIndex)
+                );
+            } else {
+                setSoldierUnitsDefendersAsRender((prev) =>
+                    moveWithin(prev, sourceIndex, targetIndex)
+                );
+            }
+            return;
+        }
+
+        // Animate entire column swap regardless of index: swap all attackers <-> defenders
+        setIsSwappingColumns(
+            targetTeam === "Attackers" ? "toAttackers" : "toDefenders"
+        );
+        setTimeout(() => {
+            setSoldierUnitsAttackersAsRender((prevA) =>
+                soldierUnitsDefendersAsRender.map((u, i) => ({
+                    ...u,
+                    id: i,
+                    team: "Attackers",
+                }))
+            );
+            setSoldierUnitsDefendersAsRender((prevD) =>
+                soldierUnitsAttackersAsRender.map((u, i) => ({
+                    ...u,
+                    id: i,
+                    team: "Defenders",
+                }))
+            );
+            setTimeout(() => setIsSwappingColumns(null), 180);
+        }, 80);
     };
 
     const handleAddAttacker = (typeUnit: string): void => {
@@ -192,89 +332,37 @@ const BattleGroundDetails = () => {
     };
 
     const handleIncreaseHitpoints = (id: number, team: string) => {
-        if (!checkedPosition) {
-            if (team === "Attackers") {
-                setSoldierUnitsAttackersAsRender((prev) =>
-                    prev.map((u) =>
-                        u.id === id
-                            ? { ...u, healthBefore: u.healthBefore + 1 }
-                            : u
-                    )
-                );
-            } else {
-                setSoldierUnitsDefendersAsRender((prev) =>
-                    prev.map((u) =>
-                        u.id === id
-                            ? { ...u, healthBefore: u.healthBefore + 1 }
-                            : u
-                    )
-                );
-            }
-            analyticsLogEvent(analytics, "pc_hitpoints_plus_" + team);
+        if (team === "Attackers") {
+            setSoldierUnitsAttackersAsRender((prev) =>
+                prev.map((u) =>
+                    u.id === id ? { ...u, healthBefore: u.healthBefore + 1 } : u
+                )
+            );
         } else {
-            // Move item up in array
-            if (team === "Attackers") {
-                setSoldierUnitsAttackersAsRender((prev) => {
-                    const idx = prev.findIndex((u) => u.id === id);
-                    if (idx <= 0) return prev;
-                    const arr = [...prev];
-                    [arr[idx - 1], arr[idx]] = [arr[idx], arr[idx - 1]];
-                    return arr;
-                });
-            } else {
-                setSoldierUnitsDefendersAsRender((prev) => {
-                    const idx = prev.findIndex((u) => u.id === id);
-                    if (idx <= 0) return prev;
-                    const arr = [...prev];
-                    [arr[idx - 1], arr[idx]] = [arr[idx], arr[idx - 1]];
-                    return arr;
-                });
-            }
-            analyticsLogEvent(analytics, "pc_changed_position_up_" + team);
+            setSoldierUnitsDefendersAsRender((prev) =>
+                prev.map((u) =>
+                    u.id === id ? { ...u, healthBefore: u.healthBefore + 1 } : u
+                )
+            );
         }
+        analyticsLogEvent(analytics, "pc_hitpoints_plus_" + team);
     };
 
     const handleDecreaseHitpoints = (id: number, team: string) => {
-        if (!checkedPosition) {
-            if (team === "Attackers") {
-                setSoldierUnitsAttackersAsRender((prev) =>
-                    prev.map((u) =>
-                        u.id === id
-                            ? { ...u, healthBefore: u.healthBefore - 1 }
-                            : u
-                    )
-                );
-            } else {
-                setSoldierUnitsDefendersAsRender((prev) =>
-                    prev.map((u) =>
-                        u.id === id
-                            ? { ...u, healthBefore: u.healthBefore - 1 }
-                            : u
-                    )
-                );
-            }
-            analyticsLogEvent(analytics, "pc_hitpoints_min_" + team);
+        if (team === "Attackers") {
+            setSoldierUnitsAttackersAsRender((prev) =>
+                prev.map((u) =>
+                    u.id === id ? { ...u, healthBefore: u.healthBefore - 1 } : u
+                )
+            );
         } else {
-            // Move item down in array
-            if (team === "Attackers") {
-                setSoldierUnitsAttackersAsRender((prev) => {
-                    const idx = prev.findIndex((u) => u.id === id);
-                    if (idx === prev.length - 1 || idx < 0) return prev;
-                    const arr = [...prev];
-                    [arr[idx + 1], arr[idx]] = [arr[idx], arr[idx + 1]];
-                    return arr;
-                });
-            } else {
-                setSoldierUnitsDefendersAsRender((prev) => {
-                    const idx = prev.findIndex((u) => u.id === id);
-                    if (idx === prev.length - 1 || idx < 0) return prev;
-                    const arr = [...prev];
-                    [arr[idx + 1], arr[idx]] = [arr[idx], arr[idx + 1]];
-                    return arr;
-                });
-            }
-            analyticsLogEvent(analytics, "pc_changed_position_down_" + team);
+            setSoldierUnitsDefendersAsRender((prev) =>
+                prev.map((u) =>
+                    u.id === id ? { ...u, healthBefore: u.healthBefore - 1 } : u
+                )
+            );
         }
+        analyticsLogEvent(analytics, "pc_hitpoints_min_" + team);
     };
 
     const handleDelete = (id: number, team: string) => {
@@ -339,7 +427,7 @@ const BattleGroundDetails = () => {
             setSoldierUnitsAttackersAsRender((prev) =>
                 prev.map((u) => {
                     if (u.id === id) {
-                        return { ...u, [which]: !u[which] };
+                        return { ...u, [which]: !u[which] } as SoldierUnit;
                     }
                     return u;
                 })
@@ -425,7 +513,7 @@ const BattleGroundDetails = () => {
                             veteran: !wasVet,
                             healthMax: newMax,
                             healthBefore: newMax,
-                        };
+                        } as SoldierUnit;
                     }
                     return u;
                 })
@@ -443,7 +531,7 @@ const BattleGroundDetails = () => {
                             veteran: !wasVet,
                             healthMax: newMax,
                             healthBefore: newMax,
-                        };
+                        } as SoldierUnit;
                     }
                     return u;
                 })
@@ -472,7 +560,7 @@ const BattleGroundDetails = () => {
                             ...u,
                             healthMax: maxHealth,
                             healthBefore: maxHealth,
-                        };
+                        } as SoldierUnit;
                     }
                     return u;
                 })
@@ -487,7 +575,7 @@ const BattleGroundDetails = () => {
                             ...u,
                             healthMax: maxHealth,
                             healthBefore: maxHealth,
-                        };
+                        } as SoldierUnit;
                     }
                     return u;
                 })
@@ -651,94 +739,6 @@ const BattleGroundDetails = () => {
                 sx={{
                     display: "flex",
                     justifyContent: "space-between",
-                    mb: 0,
-                    flexFlow: "wrap",
-                    gap: "1%",
-                }}
-            >
-                <Box
-                    sx={{
-                        display: "block",
-                        maxWidth: `${SINGLE_COL_MAX_WIDTH_PX}px`,
-                        width: `${SINGLE_COLUMN_WIDTH_PERCENTAGE}%`,
-                        gap: 1,
-                    }}
-                >
-                    {soldierUnitsAttackersAsRender.map((soldierUnitAtt) => (
-                        <CardWithShadow
-                            key={`attacker-${soldierUnitAtt.id}-${soldierUnitAtt.typeUnit}`}
-                        >
-                            <SoldierUnitAsRender
-                                key={`attacker-unit-${soldierUnitAtt.id}-${soldierUnitAtt.typeUnit}`}
-                                soldierUnit={soldierUnitAtt}
-                                onDelete={handleDelete}
-                                onUpdateHitpoints={handleUpdateHitpoints}
-                                onIncreaseHitpoints={handleIncreaseHitpoints}
-                                onDecreaseHitpoints={handleDecreaseHitpoints}
-                                onVeteranBonus={handleVeteranBonus}
-                                onDefenceBonus={handleDefenceBonus}
-                                onWallBonus={handleWallBonus}
-                                onSafeBonus={handleSafeBonus}
-                                onPoisonedBonus={handlePoisonedBonus}
-                                onBoostedBonus={handleBoostedBonus}
-                                onShipUnit={handleShipUnit}
-                                onSplashDamage={handleSplashDamage}
-                                onExplodeDamage={handleExplodeDamage}
-                            />
-                        </CardWithShadow>
-                    ))}
-                </Box>
-
-                <Box
-                    sx={{
-                        display: "block",
-                        maxWidth: `${SINGLE_COL_MAX_WIDTH_PX}px`,
-                        width: `${SINGLE_COLUMN_WIDTH_PERCENTAGE}%`,
-                        gap: 1,
-                    }}
-                >
-                    {soldierUnitsDefendersAsRender.map((soldierUnitDef) => (
-                        <CardWithShadow
-                            key={`defender-${soldierUnitDef.id}-${soldierUnitDef.typeUnit}`}
-                        >
-                            <SoldierUnitAsRender
-                                key={`defender-unit-${soldierUnitDef.id}-${soldierUnitDef.typeUnit}`}
-                                soldierUnit={soldierUnitDef}
-                                onDelete={handleDelete}
-                                onUpdateHitpoints={handleUpdateHitpoints}
-                                onIncreaseHitpoints={handleIncreaseHitpoints}
-                                onDecreaseHitpoints={handleDecreaseHitpoints}
-                                onVeteranBonus={handleVeteranBonus}
-                                onDefenceBonus={handleDefenceBonus}
-                                onWallBonus={handleWallBonus}
-                                onSafeBonus={handleSafeBonus}
-                                onPoisonedBonus={handlePoisonedBonus}
-                                onBoostedBonus={handleBoostedBonus}
-                                onShipUnit={handleShipUnit}
-                                onSplashDamage={handleSplashDamage}
-                                onExplodeDamage={handleExplodeDamage}
-                            />
-                        </CardWithShadow>
-                    ))}
-                </Box>
-            </Box>
-
-            <CardWithShadow sx={{ p: "0 2%", width: "100%", mt: "2px" }}>
-                <FormControlLabel
-                    control={
-                        <Checkbox
-                            checked={checkedPosition}
-                            onChange={handleChangeCheckbox}
-                        />
-                    }
-                    label="Use + and - to set order instead of health"
-                />
-            </CardWithShadow>
-
-            <Box
-                sx={{
-                    display: "flex",
-                    justifyContent: "space-between",
                     flexFlow: "wrap",
                     gap: "1%",
                     mb: 0,
@@ -755,6 +755,235 @@ const BattleGroundDetails = () => {
                     disabled={isLoading}
                 />
             </Box>
+
+            <Box
+                sx={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    mb: 0,
+                    flexFlow: "wrap",
+                    gap: "1%",
+                }}
+            >
+                <Box
+                    sx={{
+                        display: "block",
+                        maxWidth: `${SINGLE_COL_MAX_WIDTH_PX}px`,
+                        width: `${SINGLE_COLUMN_WIDTH_PERCENTAGE}%`,
+                        gap: 1,
+                    }}
+                    className={`dnd-column ${
+                        isSwappingColumns === "toDefenders"
+                            ? "swap-out-left"
+                            : ""
+                    }`}
+                >
+                    {soldierUnitsAttackersAsRender.map(
+                        (soldierUnitAtt, idx) => (
+                            <CardWithShadow
+                                key={`attacker-${soldierUnitAtt.id}-${soldierUnitAtt.typeUnit}`}
+                                draggable
+                                onDragStart={(e) =>
+                                    handleDragStart(e, "Attackers", idx)
+                                }
+                                onDrag={handleDrag}
+                                onDragOver={(e) => {
+                                    handleDragOver(e);
+                                    setHoverTarget({
+                                        team: "Attackers",
+                                        index: idx,
+                                    });
+                                }}
+                                onDrop={(e) => handleDrop(e, "Attackers", idx)}
+                                onDragEnd={handleDragEnd}
+                                className={`dnd-card ${
+                                    hoverTarget &&
+                                    hoverTarget.team === "Attackers" &&
+                                    hoverTarget.index === idx
+                                        ? "dnd-drop-target"
+                                        : ""
+                                } ${
+                                    dragContext &&
+                                    dragContext.team === "Attackers" &&
+                                    dragContext.index === idx
+                                        ? "being-dragged"
+                                        : ""
+                                }`}
+                            >
+                                <SoldierUnitAsRender
+                                    key={`attacker-unit-${soldierUnitAtt.id}-${soldierUnitAtt.typeUnit}`}
+                                    soldierUnit={soldierUnitAtt}
+                                    onDelete={handleDelete}
+                                    onUpdateHitpoints={handleUpdateHitpoints}
+                                    onIncreaseHitpoints={
+                                        handleIncreaseHitpoints
+                                    }
+                                    onDecreaseHitpoints={
+                                        handleDecreaseHitpoints
+                                    }
+                                    onVeteranBonus={handleVeteranBonus}
+                                    onDefenceBonus={handleDefenceBonus}
+                                    onWallBonus={handleWallBonus}
+                                    onSafeBonus={handleSafeBonus}
+                                    onPoisonedBonus={handlePoisonedBonus}
+                                    onBoostedBonus={handleBoostedBonus}
+                                    onShipUnit={handleShipUnit}
+                                    onSplashDamage={handleSplashDamage}
+                                    onExplodeDamage={handleExplodeDamage}
+                                />
+                            </CardWithShadow>
+                        )
+                    )}
+                    {/* Drop zone at end of list */}
+                    <CardWithShadow
+                        sx={{ p: "4px", minHeight: 8, opacity: 0.2 }}
+                        draggable={false}
+                        onDragOver={handleDragOver}
+                        onDrop={(e) =>
+                            handleDrop(
+                                e,
+                                "Attackers",
+                                soldierUnitsAttackersAsRender.length
+                            )
+                        }
+                    >
+                        <span></span>
+                    </CardWithShadow>
+                </Box>
+
+                <Box
+                    sx={{
+                        display: "block",
+                        maxWidth: `${SINGLE_COL_MAX_WIDTH_PX}px`,
+                        width: `${SINGLE_COLUMN_WIDTH_PERCENTAGE}%`,
+                        gap: 1,
+                    }}
+                    className={`dnd-column ${
+                        isSwappingColumns === "toAttackers"
+                            ? "swap-out-right"
+                            : ""
+                    }`}
+                >
+                    {soldierUnitsDefendersAsRender.map(
+                        (soldierUnitDef, idx) => (
+                            <CardWithShadow
+                                key={`defender-${soldierUnitDef.id}-${soldierUnitDef.typeUnit}`}
+                                draggable
+                                onDragStart={(e) =>
+                                    handleDragStart(e, "Defenders", idx)
+                                }
+                                onDrag={handleDrag}
+                                onDragOver={(e) => {
+                                    handleDragOver(e);
+                                    setHoverTarget({
+                                        team: "Defenders",
+                                        index: idx,
+                                    });
+                                }}
+                                onDrop={(e) => handleDrop(e, "Defenders", idx)}
+                                onDragEnd={handleDragEnd}
+                                className={`dnd-card ${
+                                    hoverTarget &&
+                                    hoverTarget.team === "Defenders" &&
+                                    hoverTarget.index === idx
+                                        ? "dnd-drop-target"
+                                        : ""
+                                } ${
+                                    dragContext &&
+                                    dragContext.team === "Defenders" &&
+                                    dragContext.index === idx
+                                        ? "being-dragged"
+                                        : ""
+                                }`}
+                            >
+                                <SoldierUnitAsRender
+                                    key={`defender-unit-${soldierUnitDef.id}-${soldierUnitDef.typeUnit}`}
+                                    soldierUnit={soldierUnitDef}
+                                    onDelete={handleDelete}
+                                    onUpdateHitpoints={handleUpdateHitpoints}
+                                    onIncreaseHitpoints={
+                                        handleIncreaseHitpoints
+                                    }
+                                    onDecreaseHitpoints={
+                                        handleDecreaseHitpoints
+                                    }
+                                    onVeteranBonus={handleVeteranBonus}
+                                    onDefenceBonus={handleDefenceBonus}
+                                    onWallBonus={handleWallBonus}
+                                    onSafeBonus={handleSafeBonus}
+                                    onPoisonedBonus={handlePoisonedBonus}
+                                    onBoostedBonus={handleBoostedBonus}
+                                    onShipUnit={handleShipUnit}
+                                    onSplashDamage={handleSplashDamage}
+                                    onExplodeDamage={handleExplodeDamage}
+                                />
+                            </CardWithShadow>
+                        )
+                    )}
+                    {/* Drop zone at end of list */}
+                    <CardWithShadow
+                        sx={{ p: "4px", minHeight: 8, opacity: 0.2 }}
+                        draggable={false}
+                        onDragOver={handleDragOver}
+                        onDrop={(e) =>
+                            handleDrop(
+                                e,
+                                "Defenders",
+                                soldierUnitsDefendersAsRender.length
+                            )
+                        }
+                    >
+                        <span></span>
+                    </CardWithShadow>
+                </Box>
+            </Box>
+
+            {dragPreview && (
+                <div
+                    style={{
+                        position: "fixed",
+                        left: dragPreview.clientX - dragPreview.clickOffsetX,
+                        top: dragPreview.clientY - dragPreview.clickOffsetY,
+                        pointerEvents: "none",
+                        zIndex: 9999,
+                        width: dragPreview.width,
+                        height: dragPreview.height,
+                    }}
+                >
+                    <CardWithShadow
+                        sx={{ mb: 0 }}
+                        style={{
+                            width: dragPreview.width,
+                            height: dragPreview.height,
+                        }}
+                    >
+                        <SoldierUnitAsRender
+                            soldierUnit={
+                                dragPreview.team === "Attackers"
+                                    ? soldierUnitsAttackersAsRender[
+                                          dragPreview.index
+                                      ]
+                                    : soldierUnitsDefendersAsRender[
+                                          dragPreview.index
+                                      ]
+                            }
+                            onDelete={() => {}}
+                            onUpdateHitpoints={() => {}}
+                            onIncreaseHitpoints={() => {}}
+                            onDecreaseHitpoints={() => {}}
+                            onVeteranBonus={() => {}}
+                            onDefenceBonus={() => {}}
+                            onWallBonus={() => {}}
+                            onSafeBonus={() => {}}
+                            onPoisonedBonus={() => {}}
+                            onBoostedBonus={() => {}}
+                            onShipUnit={() => {}}
+                            onSplashDamage={() => {}}
+                            onExplodeDamage={() => {}}
+                        />
+                    </CardWithShadow>
+                </div>
+            )}
 
             {versionConfig && (
                 <CardWithShadow sx={{ p: "3px 2%", width: "100%" }}>

--- a/src/components/cardWithShadow.tsx
+++ b/src/components/cardWithShadow.tsx
@@ -1,4 +1,5 @@
 import Box from "@mui/material/Box";
+import type React from "react";
 import { ReactNode } from "react";
 import {
     BORDER_RADIUS_DEFAULT,
@@ -13,12 +14,26 @@ interface CardWithShadowProps {
     shadowAmount?: number;
     sx?: object;
     style?: object;
+    draggable?: boolean;
+    onDragStart?: (e: React.DragEvent) => void;
+    onDrag?: (e: React.DragEvent) => void;
+    onDragOver?: (e: React.DragEvent) => void;
+    onDrop?: (e: React.DragEvent) => void;
+    onDragEnd?: (e: React.DragEvent) => void;
+    className?: string;
 }
 
 const CardWithShadow = ({
     children,
     sx = {},
     style = {},
+    draggable = false,
+    onDragStart,
+    onDrag,
+    onDragOver,
+    onDrop,
+    onDragEnd,
+    className,
 }: CardWithShadowProps) => {
     return (
         <Box
@@ -32,6 +47,13 @@ const CardWithShadow = ({
                 ...sx,
             }}
             style={style}
+            draggable={draggable}
+            onDragStart={onDragStart}
+            onDrag={onDrag}
+            onDragOver={onDragOver}
+            onDrop={onDrop}
+            onDragEnd={onDragEnd}
+            className={className}
         >
             {children}
         </Box>

--- a/tests/robot/battle_calculation.robot
+++ b/tests/robot/battle_calculation.robot
@@ -124,12 +124,8 @@ I change the health of the first defender to ${health}
     Fill Text    [id="Defenders0HitpointField"]    ${health}
     Press Keys    [id="Defenders0HitpointField"]    Enter
 
-I check the change order checkbox
-    Click    ${change_order_checkbox_selector}
-    Wait For Elements State    ${attackers_selection_selector}    visible
-
 I change first two attackers position
-    Click    ${first_attacker_health_or_move_down}
+    Drag And Drop    ${second_attacker_card}    ${first_attacker_card}
     Wait For Elements State    ${attackers_battleground_selector}    visible
 
 I remove the first attacker
@@ -137,6 +133,6 @@ I remove the first attacker
     Wait For Elements State    ${attackers_battleground_selector}    visible
 
 I toggle splsh second attacker
-    Click    ${second_attacker_splsh}
+    Click    ${second_attacker_xpld_button}
     Wait For Elements State    ${attackers_battleground_selector}    visible
 

--- a/tests/robot/common_selectors.resource
+++ b/tests/robot/common_selectors.resource
@@ -1,11 +1,21 @@
 *** Variables ***
-${attackers_battleground_selector}              div.containers > div > div.MuiBox-root.css-top6dd > div:nth-child(1)
-${defenders_battleground_selector}              div.containers > div > div.MuiBox-root.css-top6dd > div:nth-child(2)
+# Stable columns for attackers/defenders on the battleground
+${attackers_battleground_selector}              xpath=(//div[contains(@class,'dnd-column')])[1]
+${defenders_battleground_selector}              xpath=(//div[contains(@class,'dnd-column')])[2]
+
+# Pagination/selectors area (kept as-is; adjust if UI changes)
 ${attackers_selection_go_next_selector}         div.containers > div > div.MuiBox-root.css-kx72jn > div:nth-child(1) > span > div.MuiBox-root.css-gg4vpm > button:nth-child(3)
 ${attackers_selection_go_previous_selector}     div.containers > div > div.MuiBox-root.css-kx72jn > div:nth-child(1) > span > div.MuiBox-root.css-gg4vpm > button:nth-child(1)
 ${attackers_selection_selector}                 div.containers > div > div.MuiBox-root.css-kx72jn > div:nth-child(1)
 ${defenders_selection_selector}                 div.containers > div > div.MuiBox-root.css-kx72jn > div:nth-child(2)
+
+# Unit card shortcuts within attackers column
+${first_attacker_card}                          xpath=(//div[contains(@class,'dnd-column')])[1]//div[contains(@class,'dnd-card')][1]
+${second_attacker_card}                         xpath=(//div[contains(@class,'dnd-column')])[1]//div[contains(@class,'dnd-card')][2]
+
+# Delete button for first attacker (legacy selector retained for passing test)
 ${remove_first_attacker_selector}               div.containers > div > div.MuiBox-root.css-top6dd > div:nth-child(1) > div:nth-child(1) > div > div > button
-${change_order_checkbox_selector}               div.containers > div > div.MuiBox-root.css-hr1yj1 > label
-${first_attacker_health_or_move_down}           div.containers > div > div.MuiBox-root.css-top6dd > div:nth-child(1) > div:nth-child(1) > div > button:nth-child(9)
-${second_attacker_splsh}                        xpath=/html/body/div/div[2]/div/div[1]/div[1]/div[2]/div/button[4]
+
+# Splash button within attackers column (first visible 'splsh' button)
+${any_attacker_splsh_button}                    xpath=(//div[contains(@class,'dnd-column')])[1]//button[normalize-space()='splsh' or .//b[normalize-space()='splsh']][1]
+${second_attacker_xpld_button}                  xpath=(//div[contains(@class,'dnd-column')])[1]//div[contains(@class,'dnd-card')][2]//button[normalize-space()='xpld' or .//b[normalize-space()='xpld']]


### PR DESCRIPTION
The current UI sucks and has some issues:

1. The unit selector jumps around when you add a second unit. Why. I just want to add 8 swordsmen to remember that's how many it takes to kill a giant.
2. The (swap +/- behavior) button is bizarre, and you should be able to do that and change health also.
3. There is no way to swap attackers and defenders.

This PR fixes that:

1. The unit selector is at the top, as it should have been
2. Dragging the tiles swaps their order, and the (swap +/-) button is removed.
3. Dragging the attacker over the defender or vice versa swaps them.

This implements https://github.com/amigobrewbrew/polytopiacalculatorfirebase-public/issues/8 and also https://github.com/amigobrewbrew/polytopiacalculatorfirebase-public/issues/22

I vibecoded this, and refuse to look at ts that isn't svelte, so this PR won't be helping the code quality. However, it will be making your app better because OSS doesn't have anyone who cares about UX apparently except claude