### PR TITLE
Fix failing e2e tests and React warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1952,19 +1952,6 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/@jridgewell/source-map": {
-            "version": "0.3.6",
-            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-            "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.25"
-            }
-        },
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -3235,15 +3222,6 @@
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
             }
         },
-        "node_modules/buffer-from": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/cac": {
             "version": "6.7.14",
             "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -3369,15 +3347,6 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "license": "MIT"
-        },
-        "node_modules/commander": {
-            "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
@@ -5544,52 +5513,6 @@
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/terser": {
-            "version": "5.39.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
-            "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jridgewell/source-map": "^0.3.3",
-                "acorn": "^8.8.2",
-                "commander": "^2.20.0",
-                "source-map-support": "~0.5.20"
-            },
-            "bin": {
-                "terser": "bin/terser"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/terser/node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/terser/node_modules/source-map-support": {
-            "version": "0.5.21",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
-            }
         },
         "node_modules/text-table": {
             "version": "0.2.0",

--- a/src/components/cardWithShadow.tsx
+++ b/src/components/cardWithShadow.tsx
@@ -22,11 +22,11 @@ const CardWithShadow = ({
 }: CardWithShadowProps) => {
     return (
         <Box
-            boxShadow={BOX_SHADOW_DEFAULT}
             sx={{
                 p: PADDING_DEFAULT,
                 backgroundColor: CARD_COLOR,
                 border: 0,
+                boxShadow: BOX_SHADOW_DEFAULT,
                 borderRadius: BORDER_RADIUS_DEFAULT,
                 mb: MARGIN_BOTTOM_DEFAULT,
                 ...sx,

--- a/tests/e2e/battle-calculation.spec.ts
+++ b/tests/e2e/battle-calculation.spec.ts
@@ -16,8 +16,7 @@ const selectors = {
         "div.containers > div > div.MuiBox-root.css-kx72jn > div:nth-child(2)",
     removeFirstAttacker:
         "div.containers > div > div.MuiBox-root.css-top6dd > div:nth-child(1) > div:nth-child(1) > div > div > button",
-    changeOrderCheckbox:
-        "div.containers > div > div.MuiBox-root.css-hr1yj1 > label",
+    changeOrderCheckbox: "text='Use + and - to set order instead of health'",
     firstAttackerMoveDown:
         "div.containers > div > div.MuiBox-root.css-top6dd > div:nth-child(1) > div:nth-child(1) > div > button:nth-child(9)",
     secondAttackerSplsh:
@@ -47,32 +46,42 @@ async function expectAttackerHealth(page: Page, expected: number, index = 0) {
 
 async function goToNextAttackersPage(page: Page) {
     await page.click(selectors.attackersSelectionGoNext);
-    await page.locator(selectors.attackersSelection).waitFor({ state: "visible" });
+    await page
+        .locator(selectors.attackersSelection)
+        .waitFor({ state: "visible" });
 }
 
 async function goToPreviousAttackersPage(page: Page) {
     await page.click(selectors.attackersSelectionGoPrevious);
-    await page.locator(selectors.attackersSelection).waitFor({ state: "visible" });
+    await page
+        .locator(selectors.attackersSelection)
+        .waitFor({ state: "visible" });
 }
 
 async function changeAttackerHealth(page: Page, index: number, health: number) {
     const selector = `[id="Attackers${index}HitpointField"]`;
     await page.fill(selector, String(health));
     await page.press(selector, "Enter");
-    await page.locator(selectors.attackersBattleground).waitFor({ state: "visible" });
+    await page
+        .locator(selectors.attackersBattleground)
+        .waitFor({ state: "visible" });
 }
 
 async function changeDefenderHealth(page: Page, index: number, health: number) {
     const selector = `[id="Defenders${index}HitpointField"]`;
     await page.fill(selector, String(health));
     await page.press(selector, "Enter");
-    await page.locator(selectors.defendersBattleground).waitFor({ state: "visible" });
+    await page
+        .locator(selectors.defendersBattleground)
+        .waitFor({ state: "visible" });
 }
 
 async function setGameVersion(page: Page, version: string) {
     await page.click('[id="version-select"]');
     await page.click(`[data-value="${version}"]`);
-    await page.locator(selectors.defendersSelection).waitFor({ state: "visible" });
+    await page
+        .locator(selectors.defendersSelection)
+        .waitFor({ state: "visible" });
 }
 
 async function toggleDefenderDefence(page: Page) {
@@ -131,14 +140,14 @@ test.describe("Battle Calculation", () => {
     test("should calculate damage between units", async ({ page }) => {
         await addAttacker(page, "warrior");
         await addDefender(page, "warrior");
-        await expectDefenderHealth(page,5);
+        await expectDefenderHealth(page, 5);
     });
 
     test("should calculate damage between multiple units", async ({ page }) => {
         await addAttacker(page, "warrior");
         await addAttacker(page, "archer");
         await addDefender(page, "warrior");
-        await expectDefenderHealth(page,-1);
+        await expectDefenderHealth(page, -1);
     });
 
     test("should calculate damage between multiple units with poison", async ({
@@ -154,7 +163,7 @@ test.describe("Battle Calculation", () => {
         await goToPreviousAttackersPage(page);
         await addAttacker(page, "warrior");
         await addDefender(page, "giant");
-        await expectDefenderHealth(page,34);
+        await expectDefenderHealth(page, 34);
     });
 
     test("should calculate damage between units with no full health", async ({
@@ -164,8 +173,8 @@ test.describe("Battle Calculation", () => {
         await addDefender(page, "warrior");
         await changeAttackerHealth(page, 0, 7);
         await changeDefenderHealth(page, 0, 6);
-        await expectAttackerHealth(page,3);
-        await expectDefenderHealth(page,1);
+        await expectAttackerHealth(page, 3);
+        await expectDefenderHealth(page, 1);
     });
 
     test("should calculate damage between units when changing order", async ({
@@ -182,7 +191,7 @@ test.describe("Battle Calculation", () => {
         await page
             .locator(selectors.attackersBattleground)
             .waitFor({ state: "visible" });
-        await expectDefenderHealth(page,27);
+        await expectDefenderHealth(page, 27);
     });
 
     test("should calculate damage between units when removing units", async ({
@@ -195,7 +204,7 @@ test.describe("Battle Calculation", () => {
         await page
             .locator(selectors.attackersBattleground)
             .waitFor({ state: "visible" });
-        await expectDefenderHealth(page,34);
+        await expectDefenderHealth(page, 34);
     });
 
     test("should calculate damage with splash to halves", async ({ page }) => {
@@ -207,7 +216,7 @@ test.describe("Battle Calculation", () => {
         await page
             .locator(selectors.attackersBattleground)
             .waitFor({ state: "visible" });
-        await expectDefenderHealth(page,2.5);
+        await expectDefenderHealth(page, 2.5);
     });
 
     test("should calculate damage with correct rounding", async ({ page }) => {
@@ -218,7 +227,7 @@ test.describe("Battle Calculation", () => {
         await goToNextAttackersPage(page);
         await goToNextAttackersPage(page);
         await addAttacker(page, "hexapod");
-        await expectDefenderHealth(page,8);
+        await expectDefenderHealth(page, 8);
     });
 
     test("should calculate damage with DEF and POIS in version 115", async ({
@@ -228,11 +237,11 @@ test.describe("Battle Calculation", () => {
         await addAttacker(page, "warrior");
         await addDefender(page, "warrior");
         await toggleDefenderDefence(page);
-        await expectDefenderHealth(page,6);
+        await expectDefenderHealth(page, 6);
         await toggleDefenderPoison(page);
-        await expectDefenderHealth(page,5);
+        await expectDefenderHealth(page, 5);
         await toggleDefenderDefence(page);
-        await expectDefenderHealth(page,4);
+        await expectDefenderHealth(page, 4);
     });
 
     test("should calculate damage with DEF and POIS in version 108", async ({
@@ -242,10 +251,10 @@ test.describe("Battle Calculation", () => {
         await addAttacker(page, "warrior");
         await addDefender(page, "warrior");
         await toggleDefenderDefence(page);
-        await expectDefenderHealth(page,6);
+        await expectDefenderHealth(page, 6);
         await toggleDefenderPoison(page);
-        await expectDefenderHealth(page,5);
+        await expectDefenderHealth(page, 5);
         await toggleDefenderDefence(page);
-        await expectDefenderHealth(page,6);
+        await expectDefenderHealth(page, 6);
     });
 });


### PR DESCRIPTION
The PR failed because of an issue with a Playwright e2e test selector. The selector used a generated CSS class from Material-UI (`div.containers > div > div.MuiBox-root.css-hr1yj1 > label`), which broke when MUI was updated or styles changed. I replaced it with a text-based locator (`text='Use + and - to set order instead of health'`) which makes the test much more robust.

I also fixed a warning in the unit tests regarding the `boxShadow` prop on the `Box` component in `src/components/cardWithShadow.tsx`. Material-UI Box components expect system properties inside the `sx` prop, so passing `boxShadow` directly was causing a React "unknown prop" warning.

Both unit tests (`npm run test:unit`) and end-to-end tests (`npm run test:e2e`) now pass perfectly. I also ran Prettier to format the changed files.

---
*PR created automatically by Jules for task [4966168964192374906](https://jules.google.com/task/4966168964192374906) started by @amigobrewbrew*